### PR TITLE
loeschenDerSonderwuenscheFensterUndAussentueren

### DIFF
--- a/src/business/dbVerbindung/DBVerbindung.java
+++ b/src/business/dbVerbindung/DBVerbindung.java
@@ -197,6 +197,32 @@ public class DBVerbindung
         this.executeUpdate(sql.toString());
     }
 
+    // Method to delete the selected wishes in the database
+    public void loescheSonderwuensche(int[] sonderwunsch_id, int hausnummer)
+    {
+        // Überprüfen, ob das Array leer ist
+        if (sonderwunsch_id == null || sonderwunsch_id.length == 0) {
+            System.out.println("Keine Sonderwünsche übergeben.");
+            return;
+        }
+        
+        // Erstelle den dynamischen SQL-String
+        StringBuilder sql = new StringBuilder("DELETE FROM Wunschoption_haus WHERE ");
+        
+        // Füge für jede Wunschoption eine Zeile hinzu
+        for (int i = 0; i < sonderwunsch_id.length; i++) {
+            sql.append("wunschoption_id=").append(sonderwunsch_id[i]);
+            if (i < sonderwunsch_id.length - 1) {
+                sql.append(" OR "); // Komma nur zwischen den Werten, nicht am Ende
+            }
+        }
+        sql.append(" AND hausnummer=").append(hausnummer).append(";"); // Beende das SQL-Statement mit einem Semikolon
+        
+        // Debug-Ausgabe des generierten SQL-Strings
+        System.out.println("Generiertes SQL: " + sql.toString());
+        this.executeUpdate(sql.toString());
+    }
+
     /**
      * This method retrieves a map of the names of the wishes to their corresponding wunschoption_ids
      */

--- a/src/gui/fenster_aussentueren/FensterAussentuerControl.java
+++ b/src/gui/fenster_aussentueren/FensterAussentuerControl.java
@@ -51,6 +51,7 @@ public final class FensterAussentuerControl {
     public void berechnePreis() {
     	
     }
+
     public void speichereSonderwuensche(int[] sonderwunsch_id)
     {
     	try {
@@ -58,6 +59,15 @@ public final class FensterAussentuerControl {
     	} catch(Exception e)
     	{
     		this.fatView.Fehlermeldung("Es wurde kein Kunde ausgewaehlt");
+    	}
+    }
+
+    public void loescheSonderwuensche(int[] sonderwunsch_id)
+    {
+    	try {
+    	    connection.loescheSonderwuensche(sonderwunsch_id,KundeView.getComboboxValue());
+    	} catch(Exception e) {
+    		this.fatView.Fehlermeldung("Fehler beim speichern des loeschens der Sonderwuensche");
     	}
     }
 

--- a/src/gui/fenster_aussentueren/FensterAussentuerView.java
+++ b/src/gui/fenster_aussentueren/FensterAussentuerView.java
@@ -96,7 +96,9 @@ public class FensterAussentuerView extends BasisView{
 
         // Erstellen eines Arrays der richtigen Größe
         int[] ausgewaehlteSonderwuensche = new int[count];
-        int index = 0;
+        int[] abgewaehlteSonderwuensche = new int[chckBxPlatzhalter.length - count];
+        int indexSelection = 0;
+        int indexDeselection = 0;
 
         // Hinzufügen der IDs der ausgewählten Sonderwünsche in das Array
         for (int i = 0; i < chckBxPlatzhalter.length; i++) {
@@ -104,8 +106,18 @@ public class FensterAussentuerView extends BasisView{
                 try {
                     // Die Sonderwunsch-ID wird aus dem zweidimensionalen Array `sonderwuensche` gelesen
                     int sonderwunschId = Integer.parseInt(sonderwuensche[i][2]); // Annahme: Spalte 2 enthält die ID
-                    ausgewaehlteSonderwuensche[index] = sonderwunschId;
-                    index++;
+                    ausgewaehlteSonderwuensche[indexSelection] = sonderwunschId;
+                    indexSelection++;
+                } catch (NumberFormatException e) {
+                    // Falls eine ungültige ID vorhanden ist, wird sie ignoriert
+                    System.err.println("Ungültige ID für Sonderwunsch an Position " + i + ": " + sonderwuensche[i][2]);
+                }
+            } else {
+                try {
+                    // Die Sonderwunsch-ID wird aus dem zweidimensionalen Array `sonderwuensche` gelesen
+                    int sonderwunschId = Integer.parseInt(sonderwuensche[i][2]); // Annahme: Spalte 2 enthält die ID
+                    abgewaehlteSonderwuensche[indexDeselection] = sonderwunschId;
+                    indexDeselection++;
                 } catch (NumberFormatException e) {
                     // Falls eine ungültige ID vorhanden ist, wird sie ignoriert
                     System.err.println("Ungültige ID für Sonderwunsch an Position " + i + ": " + sonderwuensche[i][2]);
@@ -114,6 +126,7 @@ public class FensterAussentuerView extends BasisView{
         }
         if (fatControl.pruefeKonstellationSonderwuensche(ausgewaehlteSonderwuensche)) {
             this.fatControl.speichereSonderwuensche(ausgewaehlteSonderwuensche);
+            this.fatControl.loescheSonderwuensche(abgewaehlteSonderwuensche);
         }
         else {
         	System.out.println("Kombination ungueltig");


### PR DESCRIPTION
Das Loeschen von Sonderwuenschen fuer Fenster und Aussentueren ist durch abwaehlen der checkboxen moeglich.
Wiederholtes speichern von angewaehlten checkboxen fuehrt noch immer zu fehlern.